### PR TITLE
fix: avoid export timeout from build prefetch

### DIFF
--- a/lib/build/buildEnv.js
+++ b/lib/build/buildEnv.js
@@ -28,6 +28,7 @@ function isBuildOrExport() {
 }
 
 function isBuildPrefetchEnabled() {
+  if (process.env.BUILD_PREFETCH_ENABLED === undefined) return false
   return isTruthyEnv(process.env.BUILD_PREFETCH_ENABLED)
 }
 


### PR DESCRIPTION
## 问题

合并最新上游代码后，Vercel `yarn export` 在构建阶段触发全量 Notion block 预热。当前站点约有 463 个页面 block 需要拉取，Next.js page data collection worker 在 300 秒后被 SIGTERM，导致部署失败。

典型日志：

```text
[BuildEnv] {prefetchEnabled:true,prefetchConcurrency:8,staticPageGenerationTimeoutSec:300}
[Prefetch] start 463 page blocks concurrency=8
Sending SIGTERM signal to Next.js build worker due to timeout of 300 seconds
Error: Collecting page data ... is still timing out after 2 attempts
```

## 修复

- 默认关闭构建期全量预热。
- 只有显式设置 `BUILD_PREFETCH_ENABLED=true` 时才启用预热。
- 正常页面静态生成逻辑不变，部署时不再被全量预热阻塞。

## 验证

```text
unset BUILD_PREFETCH_ENABLED -> false
BUILD_PREFETCH_ENABLED=true -> true
BUILD_PREFETCH_ENABLED=false -> false
```

- 已执行 `git diff --check`。
- 该分支基于 `tauruszero/main` 创建，用于避免自定义分支冲突。