### PR TITLE
fix(build): clear stale Notion data cache before build

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -100,10 +100,12 @@ const preBuild = (function () {
   }
 
   const notionCacheRoot = path.resolve(__dirname, '.next', 'cache', 'notion')
+  const dataDir = path.join(notionCacheRoot, 'data')
   const prefetchDir = path.join(notionCacheRoot, 'sessions')
   const sessionFile = path.join(notionCacheRoot, 'build-session.json')
   const sessionId = `${process.env.npm_lifecycle_event}-${Date.now()}-${process.pid}`
 
+  fs.rmSync(dataDir, { recursive: true, force: true })
   fs.rmSync(prefetchDir, { recursive: true, force: true })
   fs.mkdirSync(notionCacheRoot, { recursive: true })
   fs.writeFileSync(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notion-next",
-  "version": "4.9.5.7",
+  "version": "4.9.5.8",
   "packageManager": "yarn@1.22.22",
   "homepage": "https://github.com/tangly1024/NotionNext.git",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Clear .next/cache/notion/data before build/export starts
- Prevent restored build cache from serving stale Notion post lists

## Verification
- Confirmed next.config.js includes dataDir cleanup
- git diff --check