### PR TITLE
fix: respect magzine recommend tag default

### DIFF
--- a/__tests__/themes/magzine/PostListRecommend.test.js
+++ b/__tests__/themes/magzine/PostListRecommend.test.js
@@ -1,0 +1,71 @@
+/**
+ * @jest-environment node
+ */
+
+import { siteConfig } from '@/lib/config'
+import { getTopPosts } from '@/themes/magzine/components/PostListRecommend'
+
+jest.mock('@/lib/config', () => ({
+  siteConfig: jest.fn()
+}))
+
+jest.mock('@/themes/magzine/components/PostItemCard', () => ({
+  __esModule: true,
+  default: () => null
+}))
+
+jest.mock('@/themes/magzine/components/PostListEmpty', () => ({
+  __esModule: true,
+  default: () => null
+}))
+
+jest.mock('@/themes/magzine/components/Swiper', () => ({
+  __esModule: true,
+  default: () => null
+}))
+
+const setupThemeConfig = overrides => {
+  siteConfig.mockImplementation((key, defaultVal, extendConfig = {}) => {
+    if (Object.prototype.hasOwnProperty.call(overrides, key)) {
+      return overrides[key]
+    }
+    if (Object.prototype.hasOwnProperty.call(extendConfig, key)) {
+      return extendConfig[key]
+    }
+    return defaultVal
+  })
+}
+
+describe('magzine PostListRecommend', () => {
+  beforeEach(() => {
+    siteConfig.mockReset()
+  })
+
+  it('uses the theme default recommend tag instead of falling back to latest posts', () => {
+    setupThemeConfig({})
+
+    const latestPosts = [
+      { id: 'latest', title: 'Latest post', tags: ['随笔'] }
+    ]
+    const allNavPages = [
+      { id: 'latest', title: 'Latest post', tags: ['随笔'] },
+      { id: 'recommended', title: 'Recommended post', tags: ['推荐'] }
+    ]
+
+    expect(getTopPosts({ latestPosts, allNavPages })).toEqual([
+      allNavPages[1]
+    ])
+  })
+
+  it('falls back to latest posts only when the recommend tag is intentionally blank', () => {
+    setupThemeConfig({
+      MAGZINE_RECOMMEND_POST_TAG: ''
+    })
+
+    const latestPosts = [
+      { id: 'latest', title: 'Latest post', tags: ['随笔'] }
+    ]
+
+    expect(getTopPosts({ latestPosts, allNavPages: [] })).toBe(latestPosts)
+  })
+})

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -68,19 +68,21 @@ global.ResizeObserver = class ResizeObserver {
 }
 
 // Mock matchMedia
-Object.defineProperty(window, 'matchMedia', {
-  writable: true,
-  value: jest.fn().mockImplementation(query => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: jest.fn(), // deprecated
-    removeListener: jest.fn(), // deprecated
-    addEventListener: jest.fn(),
-    removeEventListener: jest.fn(),
-    dispatchEvent: jest.fn(),
-  })),
-})
+if (typeof window !== 'undefined') {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation(query => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(), // deprecated
+      removeListener: jest.fn(), // deprecated
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  })
+}
 
 // Mock localStorage
 const localStorageMock = {
@@ -180,6 +182,8 @@ beforeEach(() => {
 // Cleanup after each test
 afterEach(() => {
   // Cleanup any side effects
-  document.body.innerHTML = ''
-  document.head.innerHTML = ''
+  if (typeof document !== 'undefined') {
+    document.body.innerHTML = ''
+    document.head.innerHTML = ''
+  }
 })

--- a/themes/magzine/components/PostListRecommend.js
+++ b/themes/magzine/components/PostListRecommend.js
@@ -44,12 +44,11 @@ const PostListRecommend = ({ latestPosts, allNavPages }) => {
 /**
  * 获取推荐置顶文章
  */
-function getTopPosts({ latestPosts, allNavPages }) {
+export function getTopPosts({ latestPosts, allNavPages }) {
+  const recommendTag = siteConfig('MAGZINE_RECOMMEND_POST_TAG', '', CONFIG)
+
   // 默认展示最近更新
-  if (
-    !siteConfig('MAGZINE_RECOMMEND_POST_TAG') ||
-    siteConfig('MAGZINE_RECOMMEND_POST_TAG') === ''
-  ) {
+  if (!recommendTag || recommendTag === '') {
     return latestPosts
   }
 
@@ -57,17 +56,17 @@ function getTopPosts({ latestPosts, allNavPages }) {
   let sortPosts = []
 
   // 排序方式
-  if (siteConfig('MAGZINE_RECOMMEND_POST_SORT_BY_UPDATE_TIME')) {
-    sortPosts = Object.create(allNavPages).sort((a, b) => {
+  if (siteConfig('MAGZINE_RECOMMEND_POST_SORT_BY_UPDATE_TIME', false, CONFIG)) {
+    sortPosts = [...allNavPages].sort((a, b) => {
       const dateA = new Date(a?.lastEditedDate)
       const dateB = new Date(b?.lastEditedDate)
       return dateB - dateA
     })
   } else {
-    sortPosts = Object.create(allNavPages)
+    sortPosts = [...allNavPages]
   }
 
-  const count = siteConfig('MAGZINE_RECOMMEND_POST_COUNT', 6)
+  const count = siteConfig('MAGZINE_RECOMMEND_POST_COUNT', 6, CONFIG)
   // 只取前4篇
   const topPosts = []
   for (const post of sortPosts) {
@@ -75,7 +74,7 @@ function getTopPosts({ latestPosts, allNavPages }) {
       break
     }
     // 查找标签
-    if (post?.tags?.indexOf(siteConfig('MAGZINE_RECOMMEND_POST_TAG')) >= 0) {
+    if (post?.tags?.indexOf(recommendTag) >= 0) {
       topPosts.push(post)
     }
   }


### PR DESCRIPTION
Fixes the Magzine home recommend section so it uses the theme default MAGZINE_RECOMMEND_POST_TAG instead of falling back to latest posts when the tag is not defined in NotionConfig. Adds regression coverage for the default recommend tag and the intentional blank-tag fallback. Tested with: npx jest --runTestsByPath E:\Workspace\NotionNext\__tests__\themes\magzine\PostListRecommend.test.js --runInBand